### PR TITLE
remove unnecessary dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,12 +29,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.quartz-scheduler</groupId>
-            <artifactId>quartz</artifactId>
-        </dependency>
-
-
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>


### PR DESCRIPTION
It's already there in `spring-boot-starter-quartz`.